### PR TITLE
Simplify schema

### DIFF
--- a/config/Migrations/20161029230233_StateMachineInit.php
+++ b/config/Migrations/20161029230233_StateMachineInit.php
@@ -48,7 +48,6 @@ class StateMachineInit extends AbstractMigration
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => true,
             ])
             ->addColumn('name', 'string', [
                 'default' => null,
@@ -71,7 +70,6 @@ class StateMachineInit extends AbstractMigration
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => true,
             ])
             ->addColumn('identifier', 'integer', [
                 'default' => null,
@@ -94,13 +92,11 @@ class StateMachineInit extends AbstractMigration
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => true,
             ])
             ->addColumn('state_machine_item_id', 'integer', [
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => true,
             ])
             ->addColumn('identifier', 'integer', [
                 'default' => null,
@@ -164,13 +160,11 @@ class StateMachineInit extends AbstractMigration
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => true,
             ])
             ->addColumn('state_machine_process_id', 'integer', [
                 'default' => null,
                 'limit' => 11,
                 'null' => false,
-                'signed' => true,
             ])
             ->addColumn('identifier', 'integer', [
                 'default' => null,
@@ -241,7 +235,6 @@ class StateMachineInit extends AbstractMigration
                 'default' => null,
                 'limit' => 11,
                 'null' => true,
-                'signed' => true,
             ])
             ->create();
 


### PR DESCRIPTION
Makes migrator run work for test harness.

in 5.x this should not be needed

Refs https://github.com/spryker/cakephp-statemachine/pull/38